### PR TITLE
Add hospitalbedform and 2 request oxygen form schemas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:14
+FROM node:10
 
 ENV PATH node_modules/.bin:$PATH
 

--- a/backend/db/schema-configs/free-oxygen-at-home-from-stepone.js
+++ b/backend/db/schema-configs/free-oxygen-at-home-from-stepone.js
@@ -1,0 +1,307 @@
+const freeOxygenAtHomeFromStepone = {
+    "id": "free-oxygen-at-home-from-stepone",
+    "item": [
+        {
+            "devNote": "",
+            "Header": {},
+            "Footer": {},
+            "title": "Free Oxygen at Home",
+            "description": "Free Oxygen at home for patients via Project StepOne",
+            "groups": [
+                {
+                    "fields": [
+                        {
+                            "label": "Name of the Patient",
+                            "id": "patientName",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        // {
+                        //     "label": "Age",
+                        //     "id": "age",
+                        //     "description": null,
+                        //     "type": "short_answer",
+                        //     "args": [],
+                        //     "validators": [],
+                        //     "answerType": [],
+                        //     "required": false
+                        // },
+                        {
+                            "label": "Date Of Birth",
+                            "id": "dateOfBirth",
+                            "description": null,
+                            "type": "date",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+                        {
+                            "label": "Gender",
+                            "id": "gender",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Male",
+                                "Female",
+                                "Others"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "City",
+                            "id": "city",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "State",
+                            "id": "state",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Andhra Pradesh",
+                                "Arunachal Pradesh",
+                                "Assam",
+                                "Bihar",
+                                "Chhattisgarh",
+                                "Goa",
+                                "Gujarat",
+                                "Haryana",
+                                "Himachal Pradesh",
+                                "Jammu and Kashmir",
+                                "Jharkhand",
+                                "Karnataka",
+                                "Kerala",
+                                "Madhya Pradesh",
+                                "Maharashtra",
+                                "Manipur",
+                                "Meghalaya",
+                                "Mizoram",
+                                "Nagaland",
+                                "Odisha",
+                                "Punjab",
+                                "Rajasthan",
+                                "Sikkim",
+                                "Tamil Nadu",
+                                "Telangana",
+                                "Tripura",
+                                "Uttarakhand",
+                                "Uttar Pradesh",
+                                "West Bengal",
+                                "Andaman and Nicobar Islands",
+                                "Chandigarh",
+                                "Dadra and Nagar Haveli",
+                                "Daman and Diu",
+                                "Delhi",
+                                "Lakshadweep",
+                                "Puducherry"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "PinCode",
+                            "id": "pinCode",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "BU number",
+                            "id": "buNumber",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+                        {
+                            "label": "ICMR number",
+                            "id": "icmrNumber",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+                        {
+                            "label": "SRF ID",
+                            "id": "srfId",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Address",
+                            "id": "address",
+                            "description": null,
+                            "type": "paragraph",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Are you covid positive ?",
+                            "id": "isCovidPositive",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Yes",
+                                "No"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Date of testing Covid Positive",
+                            "id": "positiveDate",
+                            "description": null,
+                            "type": "date",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+                        {
+                            "label": "Does the patient have any co-morbidities ?",
+                            "id": "comorbidity",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Yes",
+                                "No",
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "If any, What are the patient's comorbidities ?",
+                            "id": "comorbidity",
+                            "description": null,
+                            "type": "paragraph",
+                            "args": [                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+
+                        {
+                            "label": "Are you vaccinated ?",
+                            "id": "vaccineStatus",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Yes",
+                                "No",
+                                "Partially"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "What are your SPO2 levels ?",
+                            "id": "spo2level",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "What is the patient's condition ?",
+                            "id": "patientCondition",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Mobile Number",
+                            "id": "phone",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Caretaker Contact Number",
+                            "id": 'caretakerContactNumber',
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Caretaker Contact Name",
+                            "id": 'caretakerContactName',
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Date of testing Covid Positive",
+                            "id": "positiveDate",
+                            "description": null,
+                            "type": "date",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+                        {
+                            "label": "Do you have a BPL card ?",
+                            "id": "haveBPLCard",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Yes",
+                                "No"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+
+
+module.exports = freeOxygenAtHomeFromStepone;

--- a/backend/db/schema-configs/free-oxygen-at-home-from-stepone.js
+++ b/backend/db/schema-configs/free-oxygen-at-home-from-stepone.js
@@ -295,6 +295,27 @@ const freeOxygenAtHomeFromStepone = {
                             "answerType": [],
                             "required": true
                         },
+                        {
+                            "label": "Requester Name",
+                            "id": 'requesterName',
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Requester Contact Number",
+                            "id": 'requesterContactNumber',
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+
                     ]
                 }
             ]

--- a/backend/db/schema-configs/free-oxygen-at-home-from-stepone.js
+++ b/backend/db/schema-configs/free-oxygen-at-home-from-stepone.js
@@ -209,7 +209,7 @@ const freeOxygenAtHomeFromStepone = {
                         },
 
                         {
-                            "label": "Are you vaccinated ?",
+                            "label": "is the patient vaccinated ?",
                             "id": "vaccineStatus",
                             "description": null,
                             "type": "dropdown",
@@ -223,7 +223,7 @@ const freeOxygenAtHomeFromStepone = {
                             "required": true
                         },
                         {
-                            "label": "What are your SPO2 levels ?",
+                            "label": "What is the patient's SPO2 level ?",
                             "id": "spo2level",
                             "description": null,
                             "type": "short_answer",
@@ -271,16 +271,6 @@ const freeOxygenAtHomeFromStepone = {
                             "validators": [],
                             "answerType": [],
                             "required": true
-                        },
-                        {
-                            "label": "Date of testing Covid Positive",
-                            "id": "positiveDate",
-                            "description": null,
-                            "type": "date",
-                            "args": [],
-                            "validators": [],
-                            "answerType": [],
-                            "required": false
                         },
                         {
                             "label": "Do you have a BPL card ?",

--- a/backend/db/schema-configs/oxygen-at-home-blr-bom-del-from-stepone.js
+++ b/backend/db/schema-configs/oxygen-at-home-blr-bom-del-from-stepone.js
@@ -1,12 +1,12 @@
-const requestForHospitalBedsFromStepone = {
-    "id": "request-for-hospital-beds-from-stepone",
+const oxygenAtHomeforBlrBomDelFromStepone = {
+    "id": "oxygen-at-home-blr-bom-del-from-stepone",
     "item": [
         {
             "devNote": "",
             "Header": {},
             "Footer": {},
-            "title": "Hospital Beds",
-            "description": "Request for Hospital beds via Project StepOne",
+            "title": "Free Oxygen at Home",
+            "description": "Free Oxygen at home for patients via Project StepOne",
             "groups": [
                 {
                     "fields": [
@@ -58,55 +58,8 @@ const requestForHospitalBedsFromStepone = {
                             "label": "City",
                             "id": "city",
                             "description": null,
-                            "type": "short_answer",
-                            "args": [],
-                            "validators": [],
-                            "answerType": [],
-                            "required": true
-                        },
-                        {
-                            "label": "State",
-                            "id": "state",
-                            "description": null,
                             "type": "dropdown",
-                            "args": [
-                                "Andhra Pradesh",
-                                "Arunachal Pradesh",
-                                "Assam",
-                                "Bihar",
-                                "Chhattisgarh",
-                                "Goa",
-                                "Gujarat",
-                                "Haryana",
-                                "Himachal Pradesh",
-                                "Jammu and Kashmir",
-                                "Jharkhand",
-                                "Karnataka",
-                                "Kerala",
-                                "Madhya Pradesh",
-                                "Maharashtra",
-                                "Manipur",
-                                "Meghalaya",
-                                "Mizoram",
-                                "Nagaland",
-                                "Odisha",
-                                "Punjab",
-                                "Rajasthan",
-                                "Sikkim",
-                                "Tamil Nadu",
-                                "Telangana",
-                                "Tripura",
-                                "Uttarakhand",
-                                "Uttar Pradesh",
-                                "West Bengal",
-                                "Andaman and Nicobar Islands",
-                                "Chandigarh",
-                                "Dadra and Nagar Haveli",
-                                "Daman and Diu",
-                                "Delhi",
-                                "Lakshadweep",
-                                "Puducherry"
-                            ],
+                            "args": ["Bangalore", "Mumbai", "Delhi"],
                             "validators": [],
                             "answerType": [],
                             "required": true
@@ -198,7 +151,7 @@ const requestForHospitalBedsFromStepone = {
                             "required": true
                         },
                         {
-                            "label": "If any, What are the patient's comorbidities ?",
+                            "label": "If any, What are the patient's co-morbidities ?",
                             "id": "comorbidity",
                             "description": null,
                             "type": "paragraph",
@@ -273,8 +226,8 @@ const requestForHospitalBedsFromStepone = {
                             "required": true
                         },
                         {
-                            "label": "Would you be able to pay for a Private hospital bed ?",
-                            "id": "payingCapacityForPrivateHospital",
+                            "label": "Do you have a BPL card ?",
+                            "id": "haveBPLCard",
                             "description": null,
                             "type": "dropdown",
                             "args": [
@@ -285,22 +238,6 @@ const requestForHospitalBedsFromStepone = {
                             "answerType": [],
                             "required": true
                         },
-                        {
-                            "label": "What is the type of Bed required ?",
-                            "id": "requiredBedType",
-                            "description": null,
-                            "type": "dropdown",
-                            "args": [
-                                "Normal ward",
-                                "HDU (Oxygen)",
-                                "ICU",
-                                "ICU with Ventilator"
-                            ],
-                            "validators": [],
-                            "answerType": [],
-                            "required": true
-                        },
-
                         {
                             "label": "Requester Name",
                             "id": 'requesterName',
@@ -331,4 +268,4 @@ const requestForHospitalBedsFromStepone = {
 
 
 
-module.exports = requestForHospitalBedsFromStepone;
+module.exports = oxygenAtHomeforBlrBomDelFromStepone;

--- a/backend/db/schema-configs/oxygen-at-home-blr-bom-del-from-stepone.js
+++ b/backend/db/schema-configs/oxygen-at-home-blr-bom-del-from-stepone.js
@@ -5,8 +5,8 @@ const oxygenAtHomeforBlrBomDelFromStepone = {
             "devNote": "",
             "Header": {},
             "Footer": {},
-            "title": "Free Oxygen at Home",
-            "description": "Free Oxygen at home for patients via Project StepOne",
+            "title": "Oxygen at Home via Project StepOne",
+            "description": "Request for Oxygen at home for patients in Bangalore, Delhi and Mumbai",
             "groups": [
                 {
                     "fields": [

--- a/backend/db/schema-configs/request-for-hospital-beds-from-stepone.js
+++ b/backend/db/schema-configs/request-for-hospital-beds-from-stepone.js
@@ -1,0 +1,334 @@
+const requestForHospitalBedsFromStepone = {
+    "id": "request-for-hospital-beds-from-stepone",
+    "item": [
+        {
+            "devNote": "",
+            "Header": {},
+            "Footer": {},
+            "title": "Hospital Beds",
+            "description": "Request for Hospital beds via Project StepOne",
+            "groups": [
+                {
+                    "fields": [
+                        {
+                            "label": "Name of the Patient",
+                            "id": "patientName",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        // {
+                        //     "label": "Age",
+                        //     "id": "age",
+                        //     "description": null,
+                        //     "type": "short_answer",
+                        //     "args": [],
+                        //     "validators": [],
+                        //     "answerType": [],
+                        //     "required": false
+                        // },
+                        {
+                            "label": "Date Of Birth",
+                            "id": "dateOfBirth",
+                            "description": null,
+                            "type": "date",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+                        {
+                            "label": "Gender",
+                            "id": "gender",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Male",
+                                "Female",
+                                "Others"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "City",
+                            "id": "city",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "State",
+                            "id": "state",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Andhra Pradesh",
+                                "Arunachal Pradesh",
+                                "Assam",
+                                "Bihar",
+                                "Chhattisgarh",
+                                "Goa",
+                                "Gujarat",
+                                "Haryana",
+                                "Himachal Pradesh",
+                                "Jammu and Kashmir",
+                                "Jharkhand",
+                                "Karnataka",
+                                "Kerala",
+                                "Madhya Pradesh",
+                                "Maharashtra",
+                                "Manipur",
+                                "Meghalaya",
+                                "Mizoram",
+                                "Nagaland",
+                                "Odisha",
+                                "Punjab",
+                                "Rajasthan",
+                                "Sikkim",
+                                "Tamil Nadu",
+                                "Telangana",
+                                "Tripura",
+                                "Uttarakhand",
+                                "Uttar Pradesh",
+                                "West Bengal",
+                                "Andaman and Nicobar Islands",
+                                "Chandigarh",
+                                "Dadra and Nagar Haveli",
+                                "Daman and Diu",
+                                "Delhi",
+                                "Lakshadweep",
+                                "Puducherry"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "PinCode",
+                            "id": "pinCode",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "BU number",
+                            "id": "buNumber",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+                        {
+                            "label": "ICMR number",
+                            "id": "icmrNumber",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+                        {
+                            "label": "SRF ID",
+                            "id": "srfId",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Address",
+                            "id": "address",
+                            "description": null,
+                            "type": "paragraph",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Are you covid positive ?",
+                            "id": "isCovidPositive",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Yes",
+                                "No"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Date of testing Covid Positive",
+                            "id": "positiveDate",
+                            "description": null,
+                            "type": "date",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+                        {
+                            "label": "Does the patient have any co-morbidities ?",
+                            "id": "comorbidity",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Yes",
+                                "No",
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "If any, What are the patient's comorbidities ?",
+                            "id": "comorbidity",
+                            "description": null,
+                            "type": "paragraph",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": false
+                        },
+
+                        {
+                            "label": "is the patient vaccinated ?",
+                            "id": "vaccineStatus",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Yes",
+                                "No",
+                                "Partially"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "What is the patient's SPO2 level ?",
+                            "id": "spo2level",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "What is the patient's condition ?",
+                            "id": "patientCondition",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Mobile Number",
+                            "id": "phone",
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Caretaker Contact Number",
+                            "id": 'caretakerContactNumber',
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Caretaker Contact Name",
+                            "id": 'caretakerContactName',
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Would you be able to pay for a Private hospital bed ?",
+                            "id": "payingCapacityForPrivateHospital",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Yes",
+                                "No"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "What is the type of Bed required ?",
+                            "id": "requiredBedType",
+                            "description": null,
+                            "type": "dropdown",
+                            "args": [
+                                "Normal ward",
+                                "HDU (Oxygen)",
+                                "ICU",
+                                "ICU with Ventilator"
+                            ],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+
+                        {
+                            "label": "Requester Name",
+                            "id": 'requesterName',
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+                        {
+                            "label": "Requester Contact Number",
+                            "id": 'requesterContactNumber',
+                            "description": null,
+                            "type": "short_answer",
+                            "args": [],
+                            "validators": [],
+                            "answerType": [],
+                            "required": true
+                        },
+
+                    ]
+                }
+            ]
+        }
+    ]
+};
+
+
+
+module.exports = freeOxygenAtHomeFromStepone;

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "start": "react-scripts start",
     "prebuild": "rm -rf ../backend/build",
     "build": "react-scripts build",
-    "postbuild" : "mv -f build ../backend/",
+    "postbuild": "mv -f build ../backend/",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Context:
- Recording patient's date of birth is a better field to capture since age can be calculated from the date of birth. The person filling out the form would have to calculate the age otherwise. User would undertake lesser cognitive effort in recording the date of birth in comparison to calculating the age mentally.
- Geographical State has been requested for segregation in forms that are open scoped to cities. Since there exist a lot of cities and there might be differences in the way they are spelled, capturing the state I felt would be useful.
- BU# or ICMR# or SRF#: these are split into 3 different fields; There is a possibility where BU number and ICMR ids aren't issued yet but the SRF ID is generated for every sample and that can be used. Patterns for each can vary and IMO recording them independently allows us to maintain sanity of data.
- Comorbidity: list of comorbidities isn't closed scoped. There are comorbidities that can result people being immunocompromised but aren't diabetes, blood pressure or directly covid related, such as chemotherapy. Asking them if they have comorbidities and if so, asking them for more context on it, I felt would be a better approach than providing them with a multiple choice with a limited set of options, since the form does not support other addition of new dropdown entries and programmatic rendering.
- Vaccine status: has 3 states; Getting the first does implies that the patient is partially vaccinated. Upon receiving the second dose, they are completely vaccinated. Without receiving either of the doses, they are not vaccinated.
- Need to handle timestamping